### PR TITLE
Bug fixed in RLESparseResourceAllocation

### DIFF
--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/RLESparseResourceAllocation.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/reservation/RLESparseResourceAllocation.java
@@ -440,7 +440,13 @@ public class RLESparseResourceAllocation {
       if (eB == null || eB.getValue() == null) {
         return null;
       }
-      if (op == RLEOperator.subtract) {
+      if (op == RLEOperator.subtract || op == RLEOperator.subtractTestNonNegative) {
+        if ( op == RLEOperator.subtractTestNonNegative && (Resources.fitsIn(Resources.negate(eB.getValue()), ZERO_RESOURCE)
+                && !Resources.equals(Resources.negate(eB.getValue()), ZERO_RESOURCE))) {
+          throw new PlanningException(
+                  "RLESparseResourceAllocation: merge failed as the "
+                          + "resulting RLESparseResourceAllocation would be negative");
+        }
         return Resources.negate(eB.getValue());
       } else {
         return eB.getValue();


### PR DESCRIPTION
Found a bug in the handling of operator subtractTestNonNegative where a check was missing when dealing with null values. The missing check was added.

The developer performs the operation, operandA operator operandB with separate handling for operator subtractTestNonNegative. The merge function throws PlanningException in case the operator is subtractTestNonNegative, and the result would contain a negative value. 

The code checks for the following conditions:
1. Operands are Map_A and Map_B, where we check if( A is null OR A is empty), then throw an error (if after iterating over all values of B, none is NULL)
2. Next, we iterate over all values of Map_A and Map_B and check if (key_A is null OR value_A is null), then throw an error (if key_B != null and value_B != null)
3. Last, if (key_A != null and value_A != null and  key_B != null and value_B != null), then check if (value_B > value_A) then throw an exception
In code, the 2nd check was missing
