### PR TITLE
HADOOP-<JIRA ID>. The check logic for erasedIndexes in XORRawDecoder is buggy

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.io.erasurecode.ErasureCoderOptions;
 
 import java.nio.ByteBuffer;
 
+import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
+
 /**
  * A raw decoder in XOR code scheme in pure Java, adapted from HDFS-RAID.
  *
@@ -42,13 +44,16 @@ public class XORRawDecoder extends RawErasureDecoder {
         decodingState.decodeLength);
     ByteBuffer output = decodingState.outputs[0];
 
-    int erasedIdx = decodingState.erasedIndexes[0];
-
     // Process the inputs.
     int iIdx, oIdx;
     for (int i = 0; i < decodingState.inputs.length; i++) {
-      // Skip the erased location.
-      if (i == erasedIdx) {
+      // Skip the erased locations.
+      if (Ints.asList(decodingState.erasedIndexes).contains(i)) {
+        continue;
+      }
+      
+      // Skip the extra redundant items.
+      if (decodingState.inputs[i] == null) {
         continue;
       }
 
@@ -67,13 +72,17 @@ public class XORRawDecoder extends RawErasureDecoder {
     int dataLen = decodingState.decodeLength;
     CoderUtil.resetOutputBuffers(decodingState.outputs,
         decodingState.outputOffsets, dataLen);
-    int erasedIdx = decodingState.erasedIndexes[0];
 
     // Process the inputs.
     int iIdx, oIdx;
     for (int i = 0; i < decodingState.inputs.length; i++) {
-      // Skip the erased location.
-      if (i == erasedIdx) {
+      // Skip the erased locations.
+      if (Ints.asList(decodingState.erasedIndexes).contains(i)) {
+        continue;
+      }
+      
+      // Skip the extra redundant items.
+      if (decodingState.inputs[i] == null) {
         continue;
       }
 

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.io.erasurecode.ErasureCoderOptions;
 
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import org.apache.hadoop.thirdparty.com.google.common.primitives.Ints;
 
@@ -44,14 +45,16 @@ public class XORRawDecoder extends RawErasureDecoder {
         decodingState.decodeLength);
     ByteBuffer output = decodingState.outputs[0];
 
+    List<Integer> erasedIdxs = Ints.asList(decodingState.erasedIndexes);
+
     // Process the inputs.
     int iIdx, oIdx;
     for (int i = 0; i < decodingState.inputs.length; i++) {
       // Skip the erased location/s.
-      if (Ints.asList(decodingState.erasedIndexes).contains(i)) {
+      if (erasedIdxs.contains(i)) {
         continue;
       }
-      
+
       // Skip the extra redundant item/s.
       if (decodingState.inputs[i] == null) {
         continue;
@@ -73,14 +76,16 @@ public class XORRawDecoder extends RawErasureDecoder {
     CoderUtil.resetOutputBuffers(decodingState.outputs,
         decodingState.outputOffsets, dataLen);
 
+    List<Integer> erasedIdxs = Ints.asList(decodingState.erasedIndexes);
+
     // Process the inputs.
     int iIdx, oIdx;
     for (int i = 0; i < decodingState.inputs.length; i++) {
       // Skip the erased location/s.
-      if (Ints.asList(decodingState.erasedIndexes).contains(i)) {
+      if (erasedIdxs.contains(i)) {
         continue;
       }
-      
+
       // Skip the extra redundant item/s.
       if (decodingState.inputs[i] == null) {
         continue;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
@@ -47,12 +47,12 @@ public class XORRawDecoder extends RawErasureDecoder {
     // Process the inputs.
     int iIdx, oIdx;
     for (int i = 0; i < decodingState.inputs.length; i++) {
-      // Skip the erased locations.
+      // Skip the erased location/s.
       if (Ints.asList(decodingState.erasedIndexes).contains(i)) {
         continue;
       }
       
-      // Skip the extra redundant items.
+      // Skip the extra redundant item/s.
       if (decodingState.inputs[i] == null) {
         continue;
       }
@@ -76,12 +76,12 @@ public class XORRawDecoder extends RawErasureDecoder {
     // Process the inputs.
     int iIdx, oIdx;
     for (int i = 0; i < decodingState.inputs.length; i++) {
-      // Skip the erased locations.
+      // Skip the erased location/s.
       if (Ints.asList(decodingState.erasedIndexes).contains(i)) {
         continue;
       }
       
-      // Skip the extra redundant items.
+      // Skip the extra redundant item/s.
       if (decodingState.inputs[i] == null) {
         continue;
       }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/erasurecode/rawcoder/XORRawDecoder.java
@@ -75,7 +75,6 @@ public class XORRawDecoder extends RawErasureDecoder {
     int dataLen = decodingState.decodeLength;
     CoderUtil.resetOutputBuffers(decodingState.outputs,
         decodingState.outputOffsets, dataLen);
-
     List<Integer> erasedIdxs = Ints.asList(decodingState.erasedIndexes);
 
     // Process the inputs.

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/io/erasurecode/rawcoder/TestDecodingValidator.java
@@ -52,6 +52,7 @@ public class TestDecodingValidator extends TestRawCoderBase {
         {RSRawErasureCoderFactory.class, 6, 3, new int[]{2, 4}, new int[]{1}},
         {NativeRSRawErasureCoderFactory.class, 6, 3, new int[]{0}, new int[]{}},
         {XORRawErasureCoderFactory.class, 10, 1, new int[]{0}, new int[]{}},
+        {XORRawErasureCoderFactory.class, 10, 3, new int[]{0}, new int[]{}},
         {NativeXORRawErasureCoderFactory.class, 10, 1, new int[]{0},
             new int[]{}}
     });


### PR DESCRIPTION
### Description of PR

JIRA - [HADOOP-XXXXX](https://docs.google.com/document/d/1Wq-aJ59ud250FUSZPYubU0vC3oHugfYG6ujrFQdkxDE/edit?usp=sharing)

### How was this patch tested?
Added a new value set in the test class `TestDecodingValidator` to verify the code change.

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

